### PR TITLE
Feature/fetch missions

### DIFF
--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -22,8 +22,39 @@ const missionSlice = createSlice({
   name: 'missions',
   initialState,
   reducers: {
+    join: (state, action) => {
+      const mission = state.missions.find(
+        (mission) => mission.id === action.payload,
+      );
+      mission.status = true;
+    },
+    leave: (state, action) => {
+      const mission = state.missions.find(
+        (mission) => mission.id === action.payload,
+      );
+      mission.status = false;
+    },
   },
-  extraReducers: () => {
+  extraReducers: (builder) => {
+    builder
+      .addCase(getMissionsFromApi.fulfilled, (state, action) => {
+        if (state.missions.length === 0) {
+          state.missions = action.payload.map((mission) => {
+            const newMission = {
+              id: mission.mission_id,
+              name: mission.mission_name,
+              description: mission.description,
+              status: false,
+            };
+            return newMission;
+          });
+        }
+        state.isLoading = false;
+      })
+
+      .addCase(getMissionsFromApi.pending, (state) => {
+        state.isLoading = true;
+      });
   },
 });
 

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -1,0 +1,31 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+export const getMissionsFromApi = createAsyncThunk(
+  'missions/getMissionsFromApi',
+  async () => {
+    try {
+      const response = await fetch('https://api.spacexdata.com/v3/missions');
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      return error;
+    }
+  },
+);
+
+const initialState = {
+  missions: [],
+  isLoading: false,
+};
+
+const missionSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {
+  },
+  extraReducers: () => {
+  },
+});
+
+export default missionSlice.reducer;
+export const { join, leave } = missionSlice.actions;


### PR DESCRIPTION
[[4pt] Fetch missions - Fetch data #18](https://github.com/M-Anwar-Hussaini/Space-Travelers-Hub/issues/18)
### Requirements

- [x] Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- [x] Once the data are fetched, dispatch an action to store the selected data in the Redux store:
  - mission_id
  - mission_name
  - description